### PR TITLE
Adiciona tópico de eventos e meetups

### DIFF
--- a/topicos/aprendizado-de-maquina.md
+++ b/topicos/aprendizado-de-maquina.md
@@ -30,7 +30,7 @@
 - [Univariate Linear Regression with Gradient Descent and JS](https://github.com/javascript-machine-learning/univariate-linear-regression-gradient-descent-javascript)
 
 
-## Artigos 
+## Artigos
 
 ### Gerais
 
@@ -38,7 +38,7 @@
  - [Introdução Visual ao aprendizado de máquina](http://www.r2d3.us/uma-introducao-visual-ao-aprendizado-de-maquina-1/) [**pt-br**]
  - [Complete Guide to Parameter Tuning in XGBoost (with codes in Python)](https://www.analyticsvidhya.com/blog/2016/03/complete-guide-parameter-tuning-xgboost-with-codes-python/)
  - [I thought I was ready to start coding Neural Networks. Boy, was I wrong.](https://www.linkedin.com/pulse/i-thought-ready-start-coding-neural-networks-boy-wrong-tim-g%C3%BClke/?trackingId=U8FeIMV3JkhPqefE8iU2gQ%3D%3D&lipi=urn%3Ali%3Apage%3Ad_flagship3_feed%3BUD4Qv5VUShmFJpTbtzvOfA%3D%3D&licu=urn%3Ali%3Acontrol%3Ad_flagship3_feed-object)
- - [Machine Learning Glossary] (https://developers.google.com/machine-learning/glossary/)
+ - [Machine Learning Glossary](https://developers.google.com/machine-learning/glossary/)
 
 ### Classes Desbalanceadas
 

--- a/topicos/meetups-e-eventos.md
+++ b/topicos/meetups-e-eventos.md
@@ -1,0 +1,7 @@
+# Meetups e Eventos
+
+## 2018
+
+### Abril
+
+* 28/04 - **Rio de Janeiro, RJ** -- [PythOnRio - Abril/2018 [Edição Especial Data Science]](https://www.meetup.com/pt-BR/pythonrio/events/249433444/)

--- a/topicos/meetups-e-eventos.md
+++ b/topicos/meetups-e-eventos.md
@@ -4,4 +4,5 @@
 
 ### Abril
 
+* 26/04 - **São Paulo, SP** -- [Data Science aplicado ao negócio (PyData São Paulo)](https://www.meetup.com/pt-BR/PyData-Sao-Paulo/events/249621000/)
 * 28/04 - **Rio de Janeiro, RJ** -- [PythOnRio - Abril/2018 [Edição Especial Data Science]](https://www.meetup.com/pt-BR/pythonrio/events/249433444/)


### PR DESCRIPTION
Adicionei um arquivo de meetups e eventos, com a sugestão do issue #124. Acho que por enquanto a formatação do arquivo desse jeito parece adequada, uma separação por meses ao invés de uma separação por estados, mas modificações são bem recebidas. 
Aproveitei para adicionar um evento próximo que ocorrerá no Rio, e pretendo ir adicionando conforme eu tomar conhecimento de eventos futuros que ainda serão anunciados.
