### PR TITLE
removido link duplicado para Datasets do KDnuggets

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ No mais, é isso. Bem vinda(o), pequena(o) padawan :)
 
  - [Datasets for Machine Learning](https://docs.google.com/spreadsheets/d/1AQvZ7-Kg0lSZtG1wlgbIsrm90HaTZrJGQMz-uKRRlFw/edit#gid=0)
  - [Datasets for Data Mining and Data Science](http://www.kdnuggets.com/datasets/index.html)
- - [Data repositories](http://www.kdnuggets.com/datasets/index.html) by KDnuggets
  - [Datasets - Kaggle](https://www.kaggle.com/datasets)
  - [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets.html)
  - [data.world](https://data.world/)


### PR DESCRIPTION
Há dois links para os datasets do KDNuggets.
 - [Datasets for Data Mining and Data Science](http://www.kdnuggets.com/datasets/index.html)
 - [Data repositories](http://www.kdnuggets.com/datasets/index.html) by KDnuggets