### PR TITLE
Inserir curso de big data Spark

### DIFF
--- a/topicos/big-data.md
+++ b/topicos/big-data.md
@@ -3,6 +3,9 @@
 ## Artigos
 - [Clash of the titans: MapReduce vs. Spark for large scale data analytics](http://delivery.acm.org/10.1145/2840000/2831365/p2110-shi.pdf?ip=177.220.88.103&id=2831365&acc=ACTIVE%20SERVICE&key=344E943C9DC262BB%2E8F08AE39EA1AD728%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35&CFID=810755829&CFTOKEN=14928319&__acm__=1505758096_07af402ff5932187cc033a00d6e689ae)
 
+## Cursos
+- [Spark and Python for Big Data with PySpark](https://www.udemy.com/spark-and-python-for-big-data-with-pyspark/)
+
 ## Livros
 - [Hadoop: The Definitive Guide: Storage and Analysis at Internet Scale - Tom White](https://www.amazon.com.br/Hadoop-Definitive-Storage-Analysis-Internet-ebook/dp/B00V7B1IZC?__mk_pt_BR=%C3%85M%C3%85%C5%BD%C3%95%C3%91&keywords=hadoop&qid=1538426989&sr=8-2&ref=sr_1_2)
 - [Learning Spark: Lightning-Fast Big Data Analysis - Holden Karau, Andy Konwinski, Patrick Wendell e Matei Zaharia](https://www.amazon.com.br/Learning-Spark-Lightning-Fast-Data-Analysis-ebook/dp/B00SW0TY8O/ref=pd_sim_351_1?_encoding=UTF8&pd_rd_i=B00SW0TY8O&pd_rd_r=8eb5b852-c5bb-11e8-8690-b530844d64ad&pd_rd_w=G1PX6&pd_rd_wg=hvDb7&pf_rd_i=desktop-dp-sims&pf_rd_m=A1ZZFT5FULY4LN&pf_rd_p=d515db61-e263-47cd-b9d9-b33c1db68903&pf_rd_r=CV8PAMSNSYHNEAD0650C&pf_rd_s=desktop-dp-sims&pf_rd_t=40701&psc=1&refRID=CV8PAMSNSYHNEAD0650C)


### PR DESCRIPTION
Vi que as sugestões de big data não tinham nenhum curso. Estou fazendo esse curso de PySpark na Udemy e achei super hands-on. Trabalha com Dataframes direto e não RDDs. Pode ser bom para alguém que queira aprender a sintaxe do PySpark rapidamente, antes de ler os livros.