### PR TITLE
Corrige link quebrado da Udacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ No mais, é isso. Bem vinda(o), pequena(o) padawan :)
 
 <h3 id="iniciante">Iniciante</h3>
 
-  - [Python](https://www.python.org/) (lib [Pandas](https://pandas.pydata.org/)) ou [R](https://cloud.r-project.org/) | [R Studio](https://www.rstudio.com/products/rstudio/download/#download). [Qual aprender? Dicas Udacity](https://br.udacity.com/blog/post/aprender-python-r)
+  - [Python](https://www.python.org/) (lib [Pandas](https://pandas.pydata.org/)) ou [R](https://cloud.r-project.org/) | [R Studio](https://www.rstudio.com/products/rstudio/download/#download). [Qual aprender? Dicas Udacity](https://blog.udacity.com/2015/01/python-vs-r-learn-first.html)
   - [SQL](https://pt.khanacademy.org/computing/computer-programming/sql#sql-basics)
   - [Jupyter Notebook](http://jupyter.org/)
   - [Estatística Descritiva](https://br.udacity.com/course/intro-to-descriptive-statistics--ud827)


### PR DESCRIPTION
Alterei o link quebrado da Udacity, que apontava p/ o blog PT/BR que não existe mais. Eu não lembro ao certo o conteúdo em português, mas achei um post em inglês que acredito que é o mesmo conteúdo.